### PR TITLE
Updates keycloak version in integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,23 +9,7 @@ services:
     environment:
       POSTGRES_USER: keycloak
       POSTGRES_PASSWORD: changeme
-      POSTGRES_MULTIPLE_DATABASES: '"keycloak-4.8.0","keycloak-5.0.0"'
-
-  keycloak-4.8.0:
-    image: jboss/keycloak:4.8.0.Final
-    restart: always
-    ports:
-      - 9098:8080
-    depends_on:
-      - keycloak-db
-    environment:
-      KEYCLOAK_USER: keycloak-admin
-      KEYCLOAK_PASSWORD: changeme
-      DB_DATABASE: keycloak-4.8.0
-      DB_USER: keycloak
-      DB_PASSWORD: changeme
-      DB_ADDR: keycloak-db
-      DB_VENDOR: postgres
+      POSTGRES_MULTIPLE_DATABASES: '"keycloak-5.0.0"'
 
   keycloak-5.0.0:
     image: jboss/keycloak:5.0.0


### PR DESCRIPTION
# What

Updates keycloak version in integration tests. Now testing agains versions `4.80` and `5.0.0`.